### PR TITLE
feat: disable weather icon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,5 @@ FROM jenkins/jenkins:2.295-jdk11
 
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt --verbose
+
+COPY ./groovy-scripts/weather.groovy /usr/share/jenkins/ref/init.groovy.d/executors.groovy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkins/jenkins:2.295-jdk11
 
-COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
+COPY --chown=jenkins:jenkins plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt --verbose
 
-COPY ./groovy-scripts/weather.groovy /usr/share/jenkins/ref/init.groovy.d/executors.groovy
+COPY --chown=jenkins:jenkins ./groovy-scripts/weather.groovy /usr/share/jenkins/ref/init.groovy.d/executors.groovy

--- a/groovy-scripts/weather.groovy
+++ b/groovy-scripts/weather.groovy
@@ -1,0 +1,18 @@
+// From https://support.cloudbees.com/hc/en-us/articles/216973327
+def dryRun = false
+
+final metricToExclude = "com.cloudbees.hudson.plugins.folder.health.ProjectEnabledHealthMetric"
+final verb = dryRun ? "Would remove" : "Removing"
+Jenkins.instance.allItems(com.cloudbees.hudson.plugins.folder.AbstractFolder).each { folder ->
+    def removed = folder.healthMetrics.removeIf { metric ->
+        if (metric.class.name.equals(metricToExclude)) {
+            return false
+        }
+        println "${verb} ${metric.class.simpleName} from ${folder.name}"
+        return !dryRun
+    }
+    if (removed) {
+        folder.save()
+    }
+}
+return null


### PR DESCRIPTION
The CloudBees Advisory for infra.ci instance complains weekly that the weather icon are having slow requests.

It doesn't seem that there is a way to disable the weather icon with JCasc, neither with the Jenkins Helm chart.

Since https://groups.google.com/g/jenkins-infra/c/jDwhKfh2ejI is going in the direction of using opentelemetry, and that we already colelct metrics in both our prometheus and datadog platforms, then the weather system has a low value for our instances, while slowing down performances.

As such, this PR applies https://support.cloudbees.com/hc/en-us/articles/216973327 in the form of a Groovy script in this image.

Script output outputs the following when run on infra.ci.jenkins.io's console in dry-run mode:

```text
Would remove WorstChildHealthMetric from charts
Would remove WorstChildHealthMetric from custom-distribution-service
Would remove WorstChildHealthMetric from Docker Builds
Would remove WorstChildHealthMetric from incrementals-publisher
Would remove WorstChildHealthMetric from jenkins-wiki-exporter
Would remove WorstChildHealthMetric from k8smgmt
Would remove WorstChildHealthMetric from plugin-site
Would remove WorstChildHealthMetric from Terraform Jobs
Would remove WorstChildHealthMetric from aws
Would remove WorstChildHealthMetric from datadog
Would remove WorstChildHealthMetric from docker-404
Would remove WorstChildHealthMetric from docker-aws
Would remove WorstChildHealthMetric from docker-builder
Would remove WorstChildHealthMetric from docker-crond
Would remove WorstChildHealthMetric from docker-datadog
Would remove WorstChildHealthMetric from docker-helmfile
Would remove WorstChildHealthMetric from docker-inbound-agents
Would remove WorstChildHealthMetric from docker-jenkins-lts
Would remove WorstChildHealthMetric from docker-jenkins-weekly
Would remove WorstChildHealthMetric from docker-mirrorbits
Would remove WorstChildHealthMetric from docker-packer
Would remove WorstChildHealthMetric from docker-rsyncd
Would remove WorstChildHealthMetric from docker-terraform
Would remove WorstChildHealthMetric from jenkins.io
```

