### PR TITLE
chore: set a 30min timeout (3 retries of 10 minutes)

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,7 +1,11 @@
-buildDockerAndPublishImage('jenkins-weekly', [
-    mainBranch: 'main',
-    automaticSemanticVersioning: true,
-    gitCredentials: 'github-app-infra',
-    nextVersionCommand: 'jx-release-version -next-version=semantic:strip-prerelease',
-    metadataFromSh: 'cat Dockerfile | grep "FROM jenkins" | sed "s|FROM jenkins/jenkins:|-|" | sed "s|-jdk11||"'
-])
+retry(3) {
+    timeout(time: 10, unit: 'MINUTES') {
+        buildDockerAndPublishImage('jenkins-weekly', [
+            mainBranch: 'main',
+            automaticSemanticVersioning: true,
+            gitCredentials: 'github-app-infra',
+            nextVersionCommand: 'jx-release-version -next-version=semantic:strip-prerelease',
+            metadataFromSh: 'cat Dockerfile | grep "FROM jenkins" | sed "s|FROM jenkins/jenkins:|-|" | sed "s|-jdk11||"'
+        ])
+    }
+}


### PR DESCRIPTION
We have a lot of builds on infra.ci that seems stuck (most of the time the pod agent cannot be reached after a controller restart, because the pod had been stopped and removed).

While still not confident on the root cause, adding a circuit breaker and a timeout is not a bad practice at all.

Hence this PR add the following circuit breaker to the pipeline:

- The docker build is timeouted to 10 min.
  - Most of the builds are taking 4 to 6 min, and tests are 2 to 4 minutes.
  - Timeout means either a network isssue, or a slow agent when executing the tests
- The pipeline is retried 3 times, to ensure network transient issues or pod performances are not blocking us. But after 3 retries, it is no use to retry.