### PR TITLE
feat: add casc-groovy capability

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -30,6 +30,7 @@ cloudbees-jenkins-advisor:3.3.1
 command-launcher:1.6
 config-file-provider:3.8.0
 configuration-as-code:1.51
+configuration-as-code-groovy:1.1
 credentials:2.4.1
 credentials-binding:1.24
 datadog:2.11.0


### PR DESCRIPTION
Following up on @timja 's feedback in #204 , this PR adds the CasC-groovy plugin to allow configuring groovy script as config as code element instead of relying on legacy `$JENKINS_HOME/init.groovy.d/*.groovy` scripts in Docker images.