### PR TITLE
fix: remove github-api plugin from explicit dependencies

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -40,7 +40,6 @@ git:4.7.2
 git-client:3.7.2
 git-forensics:1.0.0
 github:1.33.1
-github-api:1.222
 github-autostatus:3.6.2
 github-branch-source:2.11.1
 github-checks:1.0.12


### PR DESCRIPTION
CloudBees Health Advisor report mentioned this plugin to be "no longer distributed",
as we were explicitly installing a "not recommended" version.

- https://support.cloudbees.com/hc/en-us/articles/4402425444635
- https://github.com/jenkins-infra/update-center2/blob/master/resources/artifact-ignores.properties#L560

This commit removes the explicit from plugins.txt and delegates
github-api installation to transitive dependencies.

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>