### PR TITLE
Use plugin manager cli for updating plugins

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,5 +1,5 @@
 ---
-name: update
+name: Update plugins
 
 on:
   schedule:
@@ -12,9 +12,14 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@v3
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
 
-      - name: Update
-        uses: jenkins-infra/uc@0.1.4
+      - run: ./bin/update-plugins-docker.sh
+        name: Update plugins
 
       - uses: tibdex/github-app-token@v1.5
         id: generate-token

--- a/bin/update-plugins.sh
+++ b/bin/update-plugins.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -ex
+
+cd "$(dirname "$0")" || exit 1
+
+echo "Updating plugins"
+
+# Fetches the latest plugin manager version via API, the asset has a version number in it unfortunately
+# So we can't just use the API to get the latest version without some parsing
+PM_CLI_DOWNLOAD_URL=$(curl -s 'https://api.github.com/repos/jenkinsci/plugin-installation-manager-tool/releases/latest' | jq -r '.assets[] | select(.content_type=="application/java-archive").browser_download_url')
+
+TMP_DIR=$(mktemp -d)
+
+wget "${PM_CLI_DOWNLOAD_URL}" -O "${TMP_DIR}/jenkins-plugin-manager.jar"
+
+CURRENT_JENKINS_VERSION=$(head -n 1 ../Dockerfile | cut -d ':' -f 2 | cut -d '-' -f 1)
+wget "https://get.jenkins.io/war/${CURRENT_JENKINS_VERSION}/jenkins.war" -O "${TMP_DIR}/jenkins.war"
+
+cd ../ || exit 1
+
+java -jar "${TMP_DIR}/jenkins-plugin-manager.jar" -f plugins.txt --available-updates --output txt --war "${TMP_DIR}/jenkins.war"  > plugins2.txt
+
+mv plugins2.txt plugins.txt
+
+git diff plugins.txt
+
+echo "Updating plugins complete"
+
+rm -rf "${TMP_DIR}"


### PR DESCRIPTION
see https://github.com/jenkins-infra/uc/issues/47 and https://github.com/jenkins-infra/uc/issues/31

uc doesn't seem to handle any plugins that swap to JEP-229.
I would prefer we don't go around re-inventing the wheel with a tool for jenkins-infra.

Either swap to pmcli or https://docs.renovatebot.com/modules/manager/jenkins/