### PR TITLE
chore(plugins): migrate from `workflow-cps-global-lib` to `pipeline-groovy-lib`

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -64,6 +64,7 @@ metrics:4.1.6.2
 pipeline-build-step:2.18
 pipeline-github:2.8-138.d766e30bb08b
 pipeline-graph-analysis:195.v5812d95a_a_2f9
+pipeline-groovy-lib:593.va_a_fc25d520e9
 pipeline-input-step:449.v77f0e8b_845c4
 pipeline-milestone-step:101.vd572fef9d926
 pipeline-model-api:2.2097.v33db_b_de764b_e
@@ -91,7 +92,6 @@ workflow-aggregator:581.v0c46fa_697ffd
 workflow-api:incrementals;org.jenkins-ci.plugins.workflow;1174.va_3d1b_702a_07b_
 workflow-basic-steps:incrementals;org.jenkins-ci.plugins.workflow;962.v44eb_d807841a_
 workflow-cps:2725.v7b_c717eb_12ce
-workflow-cps-global-lib:588.v576c103a_ff86
 workflow-durable-task-step:incrementals;org.jenkins-ci.plugins.workflow;1151.v3d3a_91c77419
 workflow-job:1186.v8def1a_5f3944
 workflow-multibranch:716.vc692a_e52371b_


### PR DESCRIPTION
`workflow-cps-global-lib` has been deprecated in favor of `pipeline-groovy-lib`

Ref: https://github.com/jenkins-infra/helpdesk/issues/3011