### PR TITLE
[JENKINS-49707] Use released versions of some plugins

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -89,10 +89,10 @@ toolenv:1.2
 variant:1.4
 warnings-ng:9.13.0
 workflow-aggregator:590.v6a_d052e5a_a_b_5
-workflow-api:incrementals;org.jenkins-ci.plugins.workflow;1174.va_3d1b_702a_07b_
-workflow-basic-steps:incrementals;org.jenkins-ci.plugins.workflow;962.v44eb_d807841a_
+workflow-api:1182.v41475e53ea_43
+workflow-basic-steps:969.vc4ec3e4854b_f
 workflow-cps:2746.v0da_83a_332669
-workflow-durable-task-step:incrementals;org.jenkins-ci.plugins.workflow;1151.v3d3a_91c77419
+workflow-durable-task-step:1164.v2334ddcf48d0
 workflow-job:1203.v7b_7023424efe
 workflow-multibranch:716.vc692a_e52371b_
 workflow-scm-step:400.v6b_89a_1317c9a_

--- a/plugins.txt
+++ b/plugins.txt
@@ -92,7 +92,7 @@ workflow-aggregator:590.v6a_d052e5a_a_b_5
 workflow-api:1182.v41475e53ea_43
 workflow-basic-steps:969.vc4ec3e4854b_f
 workflow-cps:2746.v0da_83a_332669
-workflow-durable-task-step:1164.v2334ddcf48d0
+workflow-durable-task-step:1174.v73a_9a_17edce0
 workflow-job:1203.v7b_7023424efe
 workflow-multibranch:716.vc692a_e52371b_
 workflow-scm-step:400.v6b_89a_1317c9a_


### PR DESCRIPTION
Though not yet https://github.com/jenkinsci/kubernetes-plugin/pull/1190: https://github.com/jenkins-infra/docker-jenkins-weekly/pull/512#discussion_r917130359

See https://github.com/jenkinsci/bom/pull/1252

Will include https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/249 if and when released.

@dduportal 