### PR TITLE
feat: add buildtriggerbadge plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -32,6 +32,7 @@ blueocean-web:1.25.8
 bouncycastle-api:2.26
 branch-api:2.1046.v0ca_37783ecc5
 build-name-setter:2.2.0
+buildtriggerbadge:251.vdf6ef853f3f5
 cloudbees-jenkins-advisor:3.3.3
 command-launcher:90.v669d7ccb_7c31
 config-file-provider:3.11.1


### PR DESCRIPTION
Adding the build trigger badge on infra.ci, already present on ci.jenkins.io

It will help us see at a glance replayed builds.

https://plugins.jenkins.io/buildtriggerbadge/
> This plugin displays icon(s) representing the cause(s) of a build directly in the build history. It lets you quickly know which cause triggered a build.Without this plugin, you may sometimes wonder what triggered a particular build shown in the build history.
> To know it, you have to open each link separately, which can be cumbersome.