### PR TITLE
fix (gha): should correct ouput

### DIFF
--- a/.github/workflows/plugins-update.yaml
+++ b/.github/workflows/plugins-update.yaml
@@ -42,5 +42,5 @@ jobs:
           body: |
             Changes:
             ```diff
-            ${{ steps.update-plugins.stdout }}
+            ${{ steps.update-plugins.outputs.stdout }}
             ```


### PR DESCRIPTION
isn't the outputs missing ?
as per example here : https://github.com/jenkins-infra/captain-hook/blob/f68d4afb0fe03f60da896c7258685d08a6402dae/.github/workflows/pr.yaml

and https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions