### PR TITLE
[JENKINS-49707] Pick up proposed final changes

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -153,10 +153,12 @@ variant:59.vf075fe829ccb
 warnings-ng:9.20.1
 windows-azure-storage:380.va3a027b784f4
 workflow-aggregator:590.v6a_d052e5a_a_b_5
-workflow-api:1198.v4596ea_5329b_6
+# TODO https://github.com/jenkinsci/workflow-api-plugin/pull/256
+workflow-api:incrementals;org.jenkins-ci.plugins.workflow;1199.v597ffe744637
 workflow-basic-steps:994.vd57e3ca_46d24
 workflow-cps:2802.v5ea_628154b_c2
-workflow-durable-task-step:1199.v02b_9244f8064
+# TODO https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180
+workflow-durable-task-step:incrementals;org.jenkins-ci.plugins.workflow;1296.v84036f77a_4ea
 workflow-job:1239.v71b_b_a_124a_725
 workflow-multibranch:716.vc692a_e52371b_
 workflow-scm-step:400.v6b_89a_1317c9a_


### PR DESCRIPTION
Following up #512 and countermanding #532 if you are willing to run these prior to release @dduportal. Picks up https://github.com/jenkinsci/workflow-api-plugin/pull/256 + https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180. Briefly, this would make it possible for `retry` blocks to work even if the agent outage was detected during a controller restart, as might occur for example during cluster updates (draining node pools, that sort of thing).