### PR TITLE
Revert "Address `set-output` deprecation"

### DIFF
--- a/.github/workflows/latest-weekly.yaml
+++ b/.github/workflows/latest-weekly.yaml
@@ -33,9 +33,9 @@ jobs:
           git diff
 
           if [[ $(git diff --stat) != '' ]]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "::set-output name=changed::true"
           else
-            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "::set-output name=changed::false"
           fi
 
       - name: Update plugins

--- a/.github/workflows/plugins-update.yaml
+++ b/.github/workflows/plugins-update.yaml
@@ -18,7 +18,7 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
-      - run: echo "stdout=$(./bin/update-plugins.sh)\n" >> $GITHUB_OUTPUT
+      - run: echo "::set-output name=stdout::$(./bin/update-plugins.sh)\n"
         id: update-plugins
         name: Update plugins
 


### PR DESCRIPTION
Reverts jenkins-infra/docker-jenkins-weekly#637

<details>
<summary>Error log:</summary>

```console
Run echo "stdout=$(./bin/update-plugins.sh)\n" >> $GITHUB_OUTPUT
++ dirname ./bin/update-plugins.sh
+ cd ./bin
+ echo 'Updating plugins'
++ curl -s https://api.github.com/repos/jenkinsci/plugin-installation-manager-tool/releases/latest
++ jq -r '.assets[] | select(.content_type=="application/java-archive").browser_download_url'
+ PM_CLI_DOWNLOAD_URL=https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/2.12.9/jenkins-plugin-manager-2.12.9.jar
++ mktemp -d
+ TMP_DIR=/tmp/tmp.BU2V62vhIU
+ wget --no-verbose https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/2.12.9/jenkins-plugin-manager-2.12.9.jar -O /tmp/tmp.BU2V62vhIU/jenkins-plugin-manager.jar
2022-10-17 22:25:53 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/190419065/f06517b2-c582-4bc7-9e63-af992ffacb2a?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221017%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221017T222553Z&X-Amz-Expires=300&X-Amz-Signature=be21f9854f75c117c2994a3ceed747ca5b660048f4004552303d548e6776f726&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=190419065&response-content-disposition=attachment%3B%20filename%3Djenkins-plugin-manager-2.12.9.jar&response-content-type=application%2Foctet-stream [6255224/6255224] -> "/tmp/tmp.BU2V62vhIU/jenkins-plugin-manager.jar" [1]
++ head -n 1 ../Dockerfile
++ cut -d - -f 1
++ cut -d : -f 2
+ CURRENT_JENKINS_VERSION=2.373
+ wget --no-verbose https://get.jenkins.io/war/2.373/jenkins.war -O /tmp/tmp.BU2V62vhIU/jenkins.war
2022-10-17 22:25:55 URL:https://mirror.xmission.com/jenkins/war/2.373/jenkins.war [93549596/93549596] -> "/tmp/tmp.BU2V62vhIU/jenkins.war" [1]
+ cd ../
+ java -jar /tmp/tmp.BU2V62vhIU/jenkins-plugin-manager.jar -f plugins.txt --available-updates --output txt --war /tmp/tmp.BU2V62vhIU/jenkins.war
+ mv plugins2.txt plugins.txt
+ git diff plugins.txt
+ echo 'Updating plugins complete'
+ rm -rf /tmp/tmp.BU2V62vhIU
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'diff --git a/plugins.txt b/plugins.txt'
```

</details>
