### PR TITLE
hotfix(update-plugins.sh) correct the `jq` request to use new content type for getting plugin manager CLI

### DIFF
--- a/bin/update-plugins.sh
+++ b/bin/update-plugins.sh
@@ -8,7 +8,7 @@ echo "Updating plugins"
 
 # Fetches the latest plugin manager version via API, the asset has a version number in it unfortunately
 # So we can't just use the API to get the latest version without some parsing
-PM_CLI_DOWNLOAD_URL=$(curl -s 'https://api.github.com/repos/jenkinsci/plugin-installation-manager-tool/releases/latest' | jq -r '.assets[] | select(.content_type=="application/java-archive").browser_download_url')
+PM_CLI_DOWNLOAD_URL=$(curl -s 'https://api.github.com/repos/jenkinsci/plugin-installation-manager-tool/releases/latest' | jq -r '.assets[] | select(.content_type=="application/x-java-archive").browser_download_url')
 
 TMP_DIR=$(mktemp -d)
 


### PR DESCRIPTION
Since https://github.com/jenkinsci/plugin-installation-manager-tool/releases/tag/2.12.13, the publication method changed with a direct consequence: the application type in the GitHub Releases API is now `application/x-java-archive` instead of `application/java-archive`
