### PR TITLE
fix: correct location for user content

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM jenkins/jenkins:2.425-jdk17
 
-COPY logos $JENKINS_HOME/userContent/logos
+COPY logos /usr/local/jenkins/ref/userContent/logos
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt --verbose


### PR DESCRIPTION
Fixup of #1379 

Copying to $JENKINS_HOME worked for me locally with Docker but it didn't work (as expected) with runc/containerd as it's a data volume. 

Ref: https://github.com/jenkinsci/docker#installing-more-tools