### PR TITLE
chore: remove `plugin-agent-build-history` plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -110,7 +110,6 @@ matrix-project:818.v7eb_e657db_924
 metrics:4.2.18-442.v02e107157925
 node-iterator-api:55.v3b_77d4032326
 okhttp-api:4.11.0-157.v6852a_a_fa_ec11
-pipeline-agent-build-history:6.vdb_fa_c0844c1e
 pipeline-build-step:539.v8c889169451f
 pipeline-github:2.8-155.8eab375ac9f8
 pipeline-graph-analysis:202.va_d268e64deb_3


### PR DESCRIPTION
This PR removes this plugin.

Revert:
- #1423

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3862