### PR TITLE
feat(plugins): removing Cobertura plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -43,7 +43,6 @@ cloud-stats:320.v96b_65297a_4b_b_
 cloudbees-bitbucket-branch-source:856.v04c46c86f911
 cloudbees-folder:6.858.v898218f3609d
 cloudbees-jenkins-advisor:358.v58972d19b_1f0
-cobertura:1.17
 coverage:1.7.0
 command-launcher:107.v773860566e2e
 commons-lang3-api:3.13.0-62.v7d18e55f51e2


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3880

as Cobertura had dependency on old `code-coverage-api` and is not used anymore, let's remove it.