### PR TITLE
Remove github-autostatus

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -70,7 +70,6 @@ git-client:4.6.0
 git-forensics:2.0.0
 github:1.37.3.1
 github-api:1.318-461.v7a_c09c9fa_d63
-github-autostatus:3.6.2
 github-branch-source:1767.va_7d01ea_c7256
 github-checks:554.vb_ee03a_000f65
 github-label-filter:1.0.0


### PR DESCRIPTION
Follow up to https://github.com/jenkins-infra/docker-jenkins-weekly/pull/1454 for https://github.com/jenkins-infra/helpdesk/issues/3880#issuecomment-1874089822

github-autostatus requires cobertura which requires the deprecated code coverage api. The previous removal was not successful because the first plugin in the dependency chain wasn't removed.

github-autostatus has had no releases in 4 years, do we actually use this plugin on infra.ci or weekly.ci? Checks aggregation happens through https://plugins.jenkins.io/checks-api/ and I'm not aware of an InfluxDB running to monitor builds on these instances 🤷 