### PR TITLE
Test jenkins-infra/pipeline-library#822

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,5 @@
+@Library('pipeline-library@pull/822/head') _
+
 properties([buildDiscarder(logRotator(daysToKeepStr: '15'))])
 
 buildDockerAndPublishImage('jenkins-weekly', [
@@ -7,4 +9,5 @@ buildDockerAndPublishImage('jenkins-weekly', [
     targetplatforms: 'linux/amd64,linux/arm64',
     nextVersionCommand: 'echo "$(jx-release-version -next-version=semantic:strip-prerelease)-$(grep "FROM jenkins" Dockerfile | cut -d: -f2 | cut -d- -f1)"',
     dockerBakeFile: 'docker-bake.hcl',
+    dockerBakeTarget: 'weekly-ci',
 ])

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,5 +1,3 @@
-@Library('pipeline-library@pull/822/head') _
-
 properties([buildDiscarder(logRotator(daysToKeepStr: '15'))])
 
 buildDockerAndPublishImage('jenkins-weekly', [
@@ -9,5 +7,4 @@ buildDockerAndPublishImage('jenkins-weekly', [
     targetplatforms: 'linux/amd64,linux/arm64',
     nextVersionCommand: 'echo "$(jx-release-version -next-version=semantic:strip-prerelease)-$(grep "FROM jenkins" Dockerfile | cut -d: -f2 | cut -d- -f1)"',
     dockerBakeFile: 'docker-bake.hcl',
-    dockerBakeTarget: 'weekly-ci',
 ])

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 A docker image containing the latest jenkins weekly release and plugins.
 
 By default it's built with infra.ci.jenkins.io in mind, but there is a variant for weekly.ci.jenkins.io with fewer plugins (defined in plugins-weekly.ci.jenkins.io.txt).
-To use this variant, add `-weeklyci` as suffix to the tag, ex: `jenkinsciinfra/jenkins-weekly:1.2.3-weeklyci`
+
+To use this variant, add `-weekly-ci` as suffix to the tag, ex: `jenkinsciinfra/jenkins-weekly:1.2.3-weekly-ci`
 
 ## Updating Plugins
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -20,6 +20,7 @@ target "infra-ci" {
   platforms = ["linux/amd64", "linux/arm64"]
   tags = [
     "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest",
+    "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest-infra-ci",
     notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}" : ""
   ]
 }
@@ -30,7 +31,7 @@ target "weekly-ci" {
     PLUGINS_FILE = "plugins-weekly.ci.jenkins.io.txt",
   }
   tags = [
-    "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest-weeklyci",
+    "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest-weekly-ci",
     notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}-weeklyci" : ""
   ]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -21,7 +21,7 @@ target "infra-ci" {
   tags = [
     "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest",
     "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest-infra-ci",
-    notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}" : ""
+    notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}" : "",
     notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}-infra-ci" : ""
   ]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -20,9 +20,7 @@ target "infra-ci" {
   platforms = ["linux/amd64", "linux/arm64"]
   tags = [
     "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest",
-    "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest-infra-ci",
-    notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}" : "",
-    notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}-infra-ci" : ""
+    notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}" : ""
   ]
 }
 
@@ -32,7 +30,7 @@ target "weekly-ci" {
     PLUGINS_FILE = "plugins-weekly.ci.jenkins.io.txt",
   }
   tags = [
-    "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest-weekly-ci",
-    notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}-weekly-ci" : ""
+    "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest-weeklyci",
+    notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}-weeklyci" : ""
   ]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -22,6 +22,7 @@ target "infra-ci" {
     "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest",
     "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest-infra-ci",
     notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}" : ""
+    notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}-infra-ci" : ""
   ]
 }
 
@@ -32,6 +33,6 @@ target "weekly-ci" {
   }
   tags = [
     "${REGISTRY}/${IMAGE_DEPLOY_NAME}:latest-weekly-ci",
-    notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}-weeklyci" : ""
+    notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_DEPLOY_NAME}:${TAG_NAME}-weekly-ci" : ""
   ]
 }


### PR DESCRIPTION
~This PR adapts the tags format so they can be easily determined for the cst tests of https://github.com/jenkins-infra/pipeline-library/pull/822 when specifying a target.~

No tag change needed anymore, reverting back this PR as test for https://github.com/jenkins-infra/pipeline-library/pull/822