### PR TITLE
feat: select target to build depending on the requirement of the modified files

### DIFF
--- a/.github/workflows/plugins-update.yaml
+++ b/.github/workflows/plugins-update.yaml
@@ -18,28 +18,50 @@ jobs:
           distribution: 'temurin'
           java-version: 17
 
-      - run: echo "::set-output name=stdout::$(./bin/update-plugins.sh)\n"
-        id: update-plugins
-        name: Update plugins
-
       - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         id: generate-token
         with:
           app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
           private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
 
-      - name: Create Pull Request
-        id: cpr
+      - run: echo "::set-output name=stdout::$(./bin/update-plugins.sh plugins-infra.ci.jenkins.io.txt)\n"
+        id: update-infra-ci-plugins
+        name: Update infra-ci plugins
+
+      - name: Create infra.ci.jenkins.io Pull Request
+        id: cpr-infra-ci
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 #v5
         with:
-          commit-message: 'chore(deps): update plugins'
+          commit-message: 'chore(deps): update infra.ci.jenkins.io plugins'
           signoff: false
-          title: 'chore(deps): update plugins'
+          title: 'chore(deps): update infra.ci.jenkins.io plugins'
           author: jenkins-infra-updatecli[bot] <178728+jenkins-infra-updatecli[bot]@users.noreply.github.com>
           committer: jenkins-infra-updatecli[bot] <178728+jenkins-infra-updatecli[bot]@users.noreply.github.com>
-          branch: update-plugins
+          branch: update-infra-ci-plugins
           token: ${{ steps.generate-token.outputs.token }}
-          labels: dependencies,plugins
+          labels: dependencies,infra-ci-plugins
+          body: |
+            Changes:
+            ```diff
+            ${{ steps.update-plugins.outputs.stdout }}
+            ```
+
+      - run: echo "::set-output name=stdout::$(./bin/update-plugins.sh plugins-weekly.ci.jenkins.io.txt)\n"
+        id: update-weekly-ci-plugins
+        name: Update weekly-ci plugins
+    
+      - name: Create weekly.ci.jenkins.io Pull Request
+        id: cpr-weekly-ci
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 #v5
+        with:
+          commit-message: 'chore(deps): update weekly.ci.jenkins.io plugins'
+          signoff: false
+          title: 'chore(deps): update weekly.ci.jenkins.io plugins'
+          author: jenkins-infra-updatecli[bot] <178728+jenkins-infra-updatecli[bot]@users.noreply.github.com>
+          committer: jenkins-infra-updatecli[bot] <178728+jenkins-infra-updatecli[bot]@users.noreply.github.com>
+          branch: update-weekly-ci-plugins
+          token: ${{ steps.generate-token.outputs.token }}
+          labels: dependencies,weekly-ci-plugins
           body: |
             Changes:
             ```diff

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,10 +1,32 @@
-properties([buildDiscarder(logRotator(daysToKeepStr: '15'))])
+pipeline {
+    agent { label 'jnlp-linux-arm64' }
+    options {
+        buildDiscarder(logRotator(daysToKeepStr: '15'))
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+                script {
+                    // Identify the target to build depending on the requirement of the modified files (empty if none)
+                    def target = sh(script: 'bin/select-target-from-modified-files.sh', returnStdout: true).trim()
 
-buildDockerAndPublishImage('jenkins-weekly', [
-    useContainer: false,
-    automaticSemanticVersioning: true,
-    gitCredentials: 'github-app-infra',
-    targetplatforms: 'linux/amd64,linux/arm64',
-    nextVersionCommand: 'echo "$(jx-release-version -next-version=semantic:strip-prerelease)-$(grep "FROM jenkins" Dockerfile | cut -d: -f2 | cut -d- -f1)"',
-    dockerBakeFile: 'docker-bake.hcl',
-])
+                    if (target) {
+                        echo "= Building ${target} target"
+                        buildDockerAndPublishImage('jenkins-weekly', [
+                            useContainer: false,
+                            automaticSemanticVersioning: true,
+                            gitCredentials: 'github-app-infra',
+                            targetplatforms: 'linux/amd64,linux/arm64',
+                            nextVersionCommand: 'echo "$(jx-release-version -next-version=semantic:strip-prerelease)-$(grep "FROM jenkins" Dockerfile | cut -d: -f2 | cut -d- -f1)"',
+                            dockerBakeFile: 'docker-bake.hcl',
+                            dockerBakeTarget: target,
+                        ])
+                    } else {
+                        echo 'INFO: none of the modified file(s) required a build.'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bin/select-target-from-modified-files.sh
+++ b/bin/select-target-from-modified-files.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -x
+
+# List of files requiring a build
+files_requiring_a_build=("cst.yaml" "docker-bake.hcl" "Dockerfile" "Jenkinsfile_k8s" "plugins-infra.ci.jenkins.io.txt" "plugins-weekly.ci.jenkins.io.txt" "logos/beekeeper.png" "logos/buttler_jenkins_is_the_way.png" "logos/buttler_stay_safe.png")
+
+# List of modified files which reference depends if in a pull request or not
+reference="origin/main..HEAD"
+if [[ "${CHANGE_ID}" == "" ]]; then
+    reference="HEAD^..HEAD"
+fi
+modified_files=($(git --no-pager diff "${reference}" --name-only))
+
+# Find the intersection between them
+intersection=""
+for file in "${modified_files[@]}"; do
+    if [[ "${files_requiring_a_build[@]}" =~ "${file}" ]]; then
+        intersection="${intersection}${file}"
+    fi
+done
+
+# Target everything by default
+target="default"
+
+# No target if there is no file requiring a build
+if [[ "${intersection}" == "" ]]; then
+    echo ""
+    exit 0
+fi
+
+# Target infra-ci if only its plugins list has been modified
+if [[ "${intersection}" == "plugins-infra.ci.jenkins.io.txt" ]]; then
+    target="infra-ci"
+fi
+
+# Target weekly-ci if only its plugins list has been modified
+if [[ "${intersection}" == "plugins-weekly.ci.jenkins.io.txt" ]]; then
+    target="weekly-ci"
+fi
+
+echo "${target}"

--- a/bin/update-plugins.sh
+++ b/bin/update-plugins.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+list="plugins-*.txt"
+if [[ "$#" -eq 1 ]]; then
+    list=$1
+fi
+
 cd "$(dirname "$0")" || exit 1
 
 echo "Updating plugins"
@@ -19,8 +24,8 @@ wget --no-verbose "https://get.jenkins.io/war/${CURRENT_JENKINS_VERSION}/jenkins
 
 cd ../ || exit 1
 
-# Iterate through each txt file starting with "plugins-"
-for pluginfile in plugins-*.txt; do
+# Iterate through each txt file starting with "plugins-", or the file specified as input
+for pluginfile in ${list}; do
     if [ -e "${pluginfile}" ]; then
         echo "Updating plugins file: ${pluginfile}"
 


### PR DESCRIPTION
This PR allows to build:
- Only infra.ci.jenkins.io image variant if only plugins-infra.ci.jenkins.io.txt if modified (with the update-plugins GHA)
- Only weekly.ci.jenkins.io image variant if only plugins-weekly.ci.jenkins.io.txt if modified (with the update-plugins GHA)
- Both image variants there is more than one of these files among a list of files requiring a build
- No image variant build if none of the modified file(s) is requiring a build

Tested with replays in #1470 by alternating the modified files in that PR:
- Success with only `infra-ci` target, only variant built:
  - Modified files: README.md, plugins-infra.ci.jenkins.io.txt
  - https://infra.ci.jenkins.io/job/docker-jobs/job/docker-jenkins-weekly/job/PR-1470/48/
  - Corresponding commit: https://github.com/jenkins-infra/docker-jenkins-weekly/pull/1470/commits/091c4c928cd587f8a71b12d9b78ef71c88dbb522

- Success with only `weekly-ci` target, only variant built:
  - Modified files: README.md, plugins-weekly.ci.jenkins.io.txt
  - https://infra.ci.jenkins.io/job/docker-jobs/job/docker-jenkins-weekly/job/PR-1470/50/
  - Corresponding commit: https://github.com/jenkins-infra/docker-jenkins-weekly/pull/1470/commits/c761702b2d15b84887485f3bac21c755b4ec6fd3

- Success with docker-bake.hcl modified (one of the files requiring a build), both variants built:
  - Modified files: README.md, docker-bake.hcl
  - https://infra.ci.jenkins.io/job/docker-jobs/job/docker-jenkins-weekly/job/PR-1470/54/
  - Corresponding commit: https://github.com/jenkins-infra/docker-jenkins-weekly/pull/1470/commits/834150cb69d929dd3f5f1c5f0ce0e26cc5b2e956

- Success with none of the modified files requiring a build, no variant built:
  - Modified files: README.md
  - https://infra.ci.jenkins.io/job/docker-jobs/job/docker-jenkins-weekly/job/PR-1470/52/
  - Corresponding commit: https://github.com/jenkins-infra/docker-jenkins-weekly/pull/1470/commits/3060fb15692b1615a14bc7079456606e6ebcc73a

It also allows to create distinct plugins update pull requests depending on which plugins list is updated.
  
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3887
