### PR TITLE
chore(Jenkinsfile) cleanup buildDockerAndPublishImage call

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,4 @@
-name: cd
+name: Release Drafter
 on:
   push:
   workflow_dispatch:

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -14,7 +14,6 @@ pipeline {
                     if (target) {
                         echo "= Building ${target} target"
                         buildDockerAndPublishImage('jenkins-weekly', [
-                            useContainer: false,
                             automaticSemanticVersioning: true,
                             gitCredentials: 'github-app-infra',
                             targetplatforms: 'linux/amd64,linux/arm64',

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -15,7 +15,6 @@ pipeline {
                         echo "= Building ${target} target"
                         buildDockerAndPublishImage('jenkins-weekly', [
                             automaticSemanticVersioning: true,
-                            gitCredentials: 'github-app-infra',
                             targetplatforms: 'linux/amd64,linux/arm64',
                             nextVersionCommand: 'echo "$(jx-release-version -next-version=semantic:strip-prerelease)-$(grep "FROM jenkins" Dockerfile | cut -d: -f2 | cut -d- -f1)"',
                             dockerBakeFile: 'docker-bake.hcl',


### PR DESCRIPTION
This PR:

- [`Jenkinsfile_k8s`] Removes a non-existing parameter (`useContainer`)  - (it does not make sense to build container in container and see https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildDockerAndPublishImage.groovy for reference)
- [`Jenkinsfile_k8s`] Removes a parameter which value is already the default one
- [GHA] Use the proper name for the Release Drafter workflow (CD is unrelated and scary in the context of a PR check: most probably a copy and paste from a plugin)