### PR TITLE
test: update only pipeline-graph-view in weekly.ci plugins to get a single image variant

### DIFF
--- a/plugins-weekly.ci.jenkins.io.txt
+++ b/plugins-weekly.ci.jenkins.io.txt
@@ -83,7 +83,7 @@ okhttp-api:4.11.0-157.v6852a_a_fa_ec11
 pipeline-build-step:540.vb_e8849e1a_b_d8
 pipeline-github:2.8-159.09e4403bc62f
 pipeline-graph-analysis:202.va_d268e64deb_3
-pipeline-graph-view:209.ve8c2e5305867
+pipeline-graph-view:214.v6e2833d3fea_9
 pipeline-groovy-lib:689.veec561a_dee13
 pipeline-input-step:477.v339683a_8d55e
 pipeline-milestone-step:111.v449306f708b_7


### PR DESCRIPTION
This PR updates the pipeline-graph-view plugin to its last version on weekly.ci.jenkins.io variant.

This should result in the publication of only the `-weeklyci` tag for this version, to try out https://github.com/jenkins-infra/kubernetes-management/pull/4867/

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3887#issuecomment-1894297763