### PR TITLE
feat(weekly.ci/infra.ci): remove datadog plugin

### DIFF
--- a/plugins-infra.ci.jenkins.io.txt
+++ b/plugins-infra.ci.jenkins.io.txt
@@ -55,7 +55,6 @@ credentials-binding:677.vdc9d38cb_254d
 customizable-header:96.v295683015391
 dark-theme:460.va_de13e406a_14
 data-tables-api:2.0.5-1
-datadog:7.0.0
 design-library:296.v56576267b_508
 display-url-api:2.204.vf6fddd8a_8b_e9
 docker-commons:439.va_3cb_0a_6a_fb_29

--- a/plugins-weekly.ci.jenkins.io.txt
+++ b/plugins-weekly.ci.jenkins.io.txt
@@ -33,7 +33,6 @@ credentials-binding:677.vdc9d38cb_254d
 customizable-header:96.v295683015391
 dark-theme:460.va_de13e406a_14
 data-tables-api:2.0.5-1
-datadog:7.0.0
 design-library:296.v56576267b_508
 display-url-api:2.204.vf6fddd8a_8b_e9
 docker-commons:439.va_3cb_0a_6a_fb_29


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4080

as per https://github.com/jenkins-infra/helpdesk/issues/4080#issuecomment-2095863202 depends on https://github.com/jenkins-infra/kubernetes-management/pull/5209

removing the datadog plugin as not used and prone to crashing the build xml files
