### PR TITLE
chore(Jenkinsfile_updatecli): drop redundant top-level properties()

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,10 +1,5 @@
 final String cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
 
-properties([
-    buildDiscarder(logRotator(numToKeepStr: '10')),
-    disableConcurrentBuilds(abortPrevious: true),
-])
-
 node('linux-arm64-docker') {
     timeout(time: 10, unit: 'MINUTES') {
         final String updatecliAction = env.BRANCH_IS_PRIMARY ? 'apply' : 'diff'


### PR DESCRIPTION
Ref:
- jenkins-infra/helpdesk#5242.

the top-level `properties()` here is redundant. `updatecli()` already sets `disableConcurrentBuilds` + `buildDiscarder` internally (and the cron via `cronTriggerExpression`), and since properties() is last-write that internal call is the one that actually applies. so the top-level `buildDiscarder('10')` never did anything. dropping it, same as kubernetes-management / packer-images.

retention effectively goes 10 to 50 but that's already what happens at runtime, so no real change.